### PR TITLE
importable e2e

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -55,11 +55,13 @@ Domains can be imported from Vercel using the domain name itself, e.g:
 $ terraform import vercel_domain.domain example.com
 ```
 
-For team domains, prefix the domain name with the team ID followed by a slash (`/`), e.g:
+For team domains, prefix the domain name with the team slug followed by a slash (`/`), e.g:
 
 ```
-$ terraform import vercel_domain.domain team_y4tZByVi8ZSPSvHGptjP21Lu/example.com
+$ terraform import vercel_domain.domain my-team/example.com
 ```
 
-Slashes in the team ID may be URL-escaped (percent-encoded) if needed.
+The team slug can be found in the URL for any team screen in Vercel's web interface.
+
+Slashes in the team slug may be URL-escaped (percent-encoded) if needed.
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -47,3 +47,19 @@ resource "vercel_domain" "google-com" {
 - **verified** (Boolean) If the domain has the ownership verified.
 
 
+## Importing
+
+Domains can be imported from Vercel using the domain name itself, e.g:
+
+```
+$ terraform import vercel_domain.domain example.com
+```
+
+For team domains, prefix the domain name with the team ID followed by a slash (`/`), e.g:
+
+```
+$ terraform import vercel_domain.domain team_y4tZByVi8ZSPSvHGptjP21Lu/example.com
+```
+
+Slashes in the team ID may be URL-escaped (percent-encoded) if needed.
+

--- a/docs/resources/env.md
+++ b/docs/resources/env.md
@@ -47,4 +47,19 @@ resource "vercel_env" "my_env" {
 - **id** (String) Unique id for this variable.
 - **updated_at** (Number) A number containing the date when the variable was updated in milliseconds.
 
+## Importing
+
+Use the project ID and the variable name separated by a slash (`/`), e.g:
+
+```
+$ terraform import vercel_env.env prj_1HbXTXCm5efoGQwtIdAjycJETmo7/THE_VARIABLE
+```
+
+For team projects, include the team ID as a prefix, e.g:
+
+```
+$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_1HbXTXCm5efoGQwtIdAjycJETmo7/THE_VARIABLE
+```
+
+Slashes in the project or team IDs may be URL-escaped (percent-encoded) if needed.
 

--- a/docs/resources/env.md
+++ b/docs/resources/env.md
@@ -49,17 +49,19 @@ resource "vercel_env" "my_env" {
 
 ## Importing
 
-Use the project ID and the variable name separated by a slash (`/`), e.g:
+Use the project and variable names separated by a slash (`/`), e.g:
 
 ```
-$ terraform import vercel_env.env prj_1HbXTXCm5efoGQwtIdAjycJETmo7/THE_VARIABLE
+$ terraform import vercel_env.env my-project/THE_VARIABLE
 ```
 
-For team projects, include the team ID as a prefix, e.g:
+For team projects, include the team slug as a prefix, e.g:
 
 ```
-$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_1HbXTXCm5efoGQwtIdAjycJETmo7/THE_VARIABLE
+$ terraform import vercel_project.team_app my-team/my-project/THE_VARIABLE
 ```
 
-Slashes in the project or team IDs may be URL-escaped (percent-encoded) if needed.
+The team slug can be found in the URL for any team screen in Vercel's web interface.
+
+Slashes in the project name or team slug may be URL-escaped (percent-encoded) if needed.
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -85,7 +85,7 @@ $ terraform import vercel_project.app prj_qgfWWlgVzRgIkrGVjhDi6ovmmsx8
 For team projects, prefix the project id with the team id followed by a slash (`/`), e.g:
 
 ```
-$ terraform impot vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_caqJd29Md3VVCUQogqsBgeSNPSJO
+$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_caqJd29Md3VVCUQogqsBgeSNPSJO
 ```
 
 Slashes in the project or team IDs may be URL-escaped (percent-encoded) if needed.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -82,10 +82,12 @@ Project resources can be imported using the project name, e.g:
 $ terraform import vercel_project.app my-project
 ```
 
-For team projects, prefix the project name with the team id followed by a slash (`/`), e.g:
+For team projects, prefix the project name with the team slug followed by a slash (`/`), e.g:
 
 ```
-$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/my-project
+$ terraform import vercel_project.team_app my-team/my-project
 ```
 
-Slashes in the project name or team ID may be URL-escaped (percent-encoded) if needed.
+The team slug can be found in the URL for any team screen in Vercel's web interface.
+
+Slashes in the project name or team slug may be URL-escaped (percent-encoded) if needed.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -76,16 +76,16 @@ Optional:
 
 ## Importing
 
-Use the Vercel `projectID`, e.g:
+Project resources can be imported using the project name, e.g:
 
 ```
-$ terraform import vercel_project.app prj_qgfWWlgVzRgIkrGVjhDi6ovmmsx8
+$ terraform import vercel_project.app my-project
 ```
 
-For team projects, prefix the project id with the team id followed by a slash (`/`), e.g:
+For team projects, prefix the project name with the team id followed by a slash (`/`), e.g:
 
 ```
-$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_caqJd29Md3VVCUQogqsBgeSNPSJO
+$ terraform import vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/my-project
 ```
 
-Slashes in the project or team IDs may be URL-escaped (percent-encoded) if needed.
+Slashes in the project name or team ID may be URL-escaped (percent-encoded) if needed.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -60,7 +60,6 @@ Required:
 - **repo** (String) The name of the git repository. For example: `chronark/terraform-provider-vercel`
 - **type** (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
 
-
 <a id="nestedblock--domain"></a>
 ### Nested Schema for `domain`
 
@@ -75,3 +74,18 @@ Optional:
 - **redirect_status_code** (Number) The redirect status code (301, 302, 307, 308).
 
 
+## Importing
+
+Use the Vercel `projectID`, e.g:
+
+```
+$ terraform import vercel_project.app prj_qgfWWlgVzRgIkrGVjhDi6ovmmsx8
+```
+
+For team projects, prefix the project id with the team id followed by a slash (`/`), e.g:
+
+```
+$ terraform impot vercel_project.team_app team_y4tZByVi8ZSPSvHGptjP21Lu/prj_caqJd29Md3VVCUQogqsBgeSNPSJO
+```
+
+Slashes in the project or team IDs may be URL-escaped (percent-encoded) if needed.

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -47,4 +47,13 @@ resource "vercel_env" "env" {
 - **id** (String) The unique identifier of the secret.
 - **user_id** (String) The unique identifier of the user who created the secret.
 
+## Importing
 
+Use the Vercel secret ID:
+
+```
+$ terraform import vercel_secret.thesecret sec_CTjwzonA7MCjQnDDP0yQbDc8
+```
+
+Please note that after secrets are written, Vercel does not allow reading the value.
+Subsequent operations may overwrite or replace the resource because of that.

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -126,15 +126,22 @@ func resourceDomain() *schema.Resource {
 	}
 }
 
-func resourceDomainImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceDomainImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts, err := partsFromID(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
 	domainName := parts[0]
 	if len(parts) > 1 {
-		teamID := parts[0]
-		err = d.Set("team_id", teamID)
+		client := meta.(*vercel.Client)
+
+		teamSlug := parts[0]
+		team, err := client.Team.Read(teamSlug)
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+
+		err = d.Set("team_id", team.Id)
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"net/url"
-	"strings"
 
 	"github.com/chronark/terraform-provider-vercel/pkg/vercel"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -129,26 +127,19 @@ func resourceDomain() *schema.Resource {
 }
 
 func resourceDomainImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	domainName, err := url.QueryUnescape(d.Id())
+	parts, err := partsFromID(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
-	parts := strings.Split(d.Id(), "/")
+	domainName := parts[0]
 	if len(parts) > 1 {
-		teamID, err := url.QueryUnescape(parts[0])
-		if err != nil {
-			return []*schema.ResourceData{}, err
-		}
-
+		teamID := parts[0]
 		err = d.Set("team_id", teamID)
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}
 
-		domainName, err = url.QueryUnescape(parts[1])
-		if err != nil {
-			return []*schema.ResourceData{}, err
-		}
+		domainName = parts[1]
 	}
 	err = d.Set("name", domainName)
 	if err != nil {

--- a/internal/provider/resource_env_test.go
+++ b/internal/provider/resource_env_test.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/chronark/terraform-provider-vercel/pkg/vercel"
+	"github.com/chronark/terraform-provider-vercel/pkg/vercel/env"
+	"github.com/chronark/terraform-provider-vercel/pkg/vercel/project"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccVercelEnv_import(t *testing.T) {
+
+	projectName, _ := uuid.GenerateUUID()
+	var (
+		actualProject project.Project
+		actualEnv     env.Env
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckVercelProjectDestroy(projectName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckVercelEnvConfig(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProjectStateHasValues(
+						"vercel_project.new", project.Project{Name: projectName},
+					),
+					testAccCheckVercelProjectExists("vercel_project.new", &actualProject),
+					testAccCheckVercelEnvExists("vercel_env.new", &actualEnv),
+					testAccVercelEnvImport(&actualProject, &actualEnv),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVercelEnvConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "vercel_project" "new" {
+		name = "%s"
+		git_repository {
+			type = "github"
+			repo = "chronark/terraform-provider-vercel"
+		}
+	}
+
+	resource "vercel_env" "new" {
+		key         = "FOO"
+		value       = "BAR"
+
+		project_id  = vercel_project.new.id
+		target      = [ "production" ]
+		type        = "plain"
+	}
+	`, name)
+}
+
+func testAccCheckVercelEnvExists(n string, actual *env.Env) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s in %+v", n, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No project set")
+		}
+
+		projectID := rs.Primary.Attributes["project_id"]
+		teamID := rs.Primary.Attributes["team_id"]
+
+		envs, err := vercel.New(os.Getenv("VERCEL_TOKEN")).Env.Read(projectID, teamID)
+		if err != nil {
+			return err
+		}
+		for _, env := range envs {
+			if env.ID == rs.Primary.ID {
+				*actual = env
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Could not find env '%s' in project '%s'", rs.Primary.ID, projectID)
+	}
+}
+
+func testAccVercelEnvImport(srcProject *project.Project, srcEnv *env.Env) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		data := resourceEnv().Data(nil)
+		data.SetId(srcProject.Name + "/" + srcEnv.Key)
+		ds, err := resourceEnv().Importer.StateContext(context.Background(), data, vercel.New(os.Getenv("VERCEL_TOKEN")))
+		if err != nil {
+			return err
+		}
+		if len(ds) != 1 {
+			return fmt.Errorf("Expected 1 instance state from importer function. Got %d", len(ds))
+		}
+
+		if ds[0].Id() != srcEnv.ID {
+			return fmt.Errorf("Imported env ID. Expected '%s'. Actual '%s'.", srcEnv.ID, ds[0].Id())
+		}
+		if ds[0].Get("project_id") != srcProject.ID {
+			return fmt.Errorf("Imported env project ID. Expected '%s'. Actual '%s'.", srcProject.ID, ds[0].Get("project_id").(string))
+		}
+		return nil
+	}
+}

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/chronark/terraform-provider-vercel/pkg/util"
@@ -172,13 +173,23 @@ func resourceProject() *schema.Resource {
 }
 
 func resourceProjectImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	// TODO: need to escape the slash inside project and team names?
+	projectID, err := url.QueryUnescape(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) > 1 {
-		teamID, projectID := parts[0], parts[1]
+		teamID, err := url.QueryUnescape(parts[0])
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
 		d.Set("team_id", teamID)
-		d.SetId(projectID)
+		projectID, err = url.QueryUnescape(parts[1])
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
 	}
+	d.SetId(projectID)
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -299,6 +299,8 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
+	d.SetId(project.ID)
+
 	err = d.Set("name", project.Name)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -348,9 +348,10 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		gitRepository[0]["repo"] = fmt.Sprintf("%s/%s", project.Link.ProjectNamespace, project.Link.ProjectName)
 	case "github":
 		gitRepository[0]["repo"] = fmt.Sprintf("%s/%s", project.Link.Org, project.Link.Repo)
+	case "bitbucket":
+		gitRepository[0]["repo"] = fmt.Sprintf("%s/%s", project.Link.Owner, project.Link.Slug)
 	default:
 		return diag.Errorf("Can't recognize '%s' repository type", project.Link.Type)
-		// TODO: bitbucket
 	}
 
 	err = d.Set("git_repository", gitRepository)

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -342,9 +342,17 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 	gitRepository := make([]map[string]interface{}, 1)
 	gitRepository[0] = map[string]interface{}{
 		"type": project.Link.Type,
-		// TODO: this works for the gitlab type. need to support other repo types
-		"repo": fmt.Sprintf("%s/%s", project.Link.ProjectNamespace, project.Link.ProjectName),
 	}
+	switch project.Link.Type {
+	case "gitlab":
+		gitRepository[0]["repo"] = fmt.Sprintf("%s/%s", project.Link.ProjectNamespace, project.Link.ProjectName)
+	case "github":
+		gitRepository[0]["repo"] = fmt.Sprintf("%s/%s", project.Link.Org, project.Link.Repo)
+	default:
+		return diag.Errorf("Can't recognize '%s' repository type", project.Link.Type)
+		// TODO: bitbucket
+	}
+
 	err = d.Set("git_repository", gitRepository)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -187,15 +187,21 @@ func partsFromID(id string) ([]string, error) {
 	return results, nil
 }
 
-func resourceProjectImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceProjectImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts, err := partsFromID(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
 	projectID := parts[0]
 	if len(parts) > 1 {
-		teamID := parts[0]
-		err = d.Set("team_id", teamID)
+		teamSlug := parts[0]
+		client := meta.(*vercel.Client)
+		team, err := client.Team.Read(teamSlug)
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+
+		err = d.Set("team_id", team.Id)
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -183,7 +183,12 @@ func resourceProjectImportState(ctx context.Context, d *schema.ResourceData, m i
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}
-		d.Set("team_id", teamID)
+
+		err = d.Set("team_id", teamID)
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+
 		projectID, err = url.QueryUnescape(parts[1])
 		if err != nil {
 			return []*schema.ResourceData{}, err

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -172,27 +172,35 @@ func resourceProject() *schema.Resource {
 	}
 }
 
+func partsFromID(id string) ([]string, error) {
+	parts := strings.Split(id, "/")
+	results := make([]string, len(parts))
+	for i, part := range parts {
+		result, err := url.QueryUnescape(part)
+		if err != nil {
+			return results, err
+		}
+
+		results[i] = result
+	}
+
+	return results, nil
+}
+
 func resourceProjectImportState(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	projectID, err := url.QueryUnescape(d.Id())
+	parts, err := partsFromID(d.Id())
 	if err != nil {
 		return []*schema.ResourceData{}, err
 	}
-	parts := strings.Split(d.Id(), "/")
+	projectID := parts[0]
 	if len(parts) > 1 {
-		teamID, err := url.QueryUnescape(parts[0])
-		if err != nil {
-			return []*schema.ResourceData{}, err
-		}
-
+		teamID := parts[0]
 		err = d.Set("team_id", teamID)
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}
 
-		projectID, err = url.QueryUnescape(parts[1])
-		if err != nil {
-			return []*schema.ResourceData{}, err
-		}
+		projectID = parts[1]
 	}
 	d.SetId(projectID)
 	return []*schema.ResourceData{d}, nil

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/chronark/terraform-provider-vercel/pkg/vercel"
 	"github.com/chronark/terraform-provider-vercel/pkg/vercel/secret"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -15,6 +16,10 @@ func resourceSecret() *schema.Resource {
 		CreateContext: resourceSecretCreate,
 		ReadContext:   resourceSecretRead,
 		DeleteContext: resourceSecretDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/pkg/vercel/project/types.go
+++ b/pkg/vercel/project/types.go
@@ -96,6 +96,8 @@ type Project struct {
 		DeployHooks      []interface{} `json:"deployHooks"`
 		ProjectName      string        `json:"projectName"`
 		ProjectNamespace string        `json:"projectNamespace"`
+		Owner            string        `json:"owner"`
+		Slug             string        `json:"slug"`
 	} `json:"link"`
 	LatestDeployments []struct {
 		Alias         []string      `json:"alias"`

--- a/pkg/vercel/project/types.go
+++ b/pkg/vercel/project/types.go
@@ -94,6 +94,8 @@ type Project struct {
 		Sourceless       bool          `json:"sourceless"`
 		ProductionBranch string        `json:"productionBranch"`
 		DeployHooks      []interface{} `json:"deployHooks"`
+		ProjectName      string        `json:"projectName"`
+		ProjectNamespace string        `json:"projectNamespace"`
 	} `json:"link"`
 	LatestDeployments []struct {
 		Alias         []string      `json:"alias"`


### PR DESCRIPTION
- feat: allows importing projects
- feat: reads github repository link
- feat: read repository from bitbucket project
- feat: allows importing with slashes in team/project IDs
- fix (lint): check error code
- feat: allows importing secrets and envs
- feat: allows importing domains
- docs: domain importing
- refactor: extract function for interpreting import paths
- feat: allow importing project with name
- feat: allow importing project with the much easier team slugs
- feat: allow importing envs with easier project and team refs
- feat: allow importing domains with easier team slugs
- tests: importing domain, env, project and secret
