### PR TITLE
Test and Release using go-1.16 to support darwin_arm64

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15"
+          go-version: "1.16"
         id: go
 
       - name: Check out code into the Go module directory
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.15"
+          go-version: "1.16"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.3
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2.3.3


### PR DESCRIPTION
M1 macs are growing in popularity with developers.

A local build runs fine.